### PR TITLE
fix: resolve BetterAuth Edge runtime error and Google sign-in user info

### DIFF
--- a/web/xedmail/src/app/api/auth/[...all]/route.ts
+++ b/web/xedmail/src/app/api/auth/[...all]/route.ts
@@ -4,4 +4,15 @@ export const runtime = "nodejs";
 import { auth } from "@/lib/auth";
 import { toNextJsHandler } from "better-auth/next-js";
 
-export const { GET, POST } = toNextJsHandler(auth);
+const handler = toNextJsHandler(auth);
+
+export async function GET(req: Request) {
+  const res = await handler.GET(req);
+  if (res.status >= 500) {
+    const body = await res.clone().text();
+    console.error("[auth] GET error", res.status, new URL(req.url).pathname, body);
+  }
+  return res;
+}
+
+export const { POST } = handler;

--- a/web/xedmail/src/components/app-sidebar.tsx
+++ b/web/xedmail/src/components/app-sidebar.tsx
@@ -215,7 +215,7 @@ export async function AppSidebar({
           user={{
             name: userData?.name ?? "",
             email: userData?.email ?? "",
-            avatar: "",
+            avatar: userData?.image ?? "",
           }}
         />
       </SidebarFooter>

--- a/web/xedmail/src/lib/auth.ts
+++ b/web/xedmail/src/lib/auth.ts
@@ -18,6 +18,7 @@ export const auth = betterAuth({
     google: {
       clientId: process.env.GOOGLE_CLIENT_ID!,
       clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
+      overrideUserInfoOnSignIn: true,
     },
   },
   plugins: [
@@ -53,6 +54,27 @@ export const auth = betterAuth({
             });
           } catch (err) {
             console.error("[auth] Failed to upsert user_profiles for", user.id, err);
+          }
+        },
+      },
+      // When an existing user re-signs-in via Google, BetterAuth calls user.update to
+      // refresh their profile. If jazzAuth is in context (injected by the Jazz callback
+      // hook), backfill encryptedCredentials so get-session stops returning 500.
+      update: {
+        before: async (user: Record<string, unknown>, context: Record<string, unknown>) => {
+          if (
+            context &&
+            "jazzAuth" in context &&
+            (context.jazzAuth as any)?.encryptedCredentials
+          ) {
+            const jazzAuth = context.jazzAuth as { accountID: string; encryptedCredentials: string };
+            return {
+              data: {
+                ...user,
+                accountID: jazzAuth.accountID,
+                encryptedCredentials: jazzAuth.encryptedCredentials,
+              },
+            };
           }
         },
       },

--- a/web/xedmail/src/proxy.ts
+++ b/web/xedmail/src/proxy.ts
@@ -1,6 +1,5 @@
-// web/xedmail/src/middleware.ts
+// web/xedmail/src/proxy.ts
 import { NextRequest, NextResponse } from "next/server";
-import { auth } from "@/lib/auth";
 
 const PUBLIC_PREFIXES = ["/login", "/api/auth", "/_next/"];
 const STATIC_EXT = /\.(html?|css|js|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest|json)$/;
@@ -14,14 +13,17 @@ function isApiRoute(pathname: string): boolean {
   return pathname.startsWith("/api/") && !pathname.startsWith("/api/auth");
 }
 
-export async function middleware(request: NextRequest) {
+export function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl;
 
   if (isPublic(pathname)) return NextResponse.next();
 
-  const session = await auth.api.getSession({ headers: request.headers });
+  // Importing the full `auth` instance (jazzPlugin + kysely-libsql) is not
+  // Edge-compatible and throws "invalid tag". Check the session cookie instead —
+  // full validation still happens in API routes via api-auth.ts (Node.js runtime).
+  const sessionToken = request.cookies.get("better-auth.session_token");
 
-  if (!session) {
+  if (!sessionToken) {
     if (isApiRoute(pathname)) {
       return NextResponse.json({ error: "UNAUTHORIZED" }, { status: 401 });
     }


### PR DESCRIPTION
## Summary

- Replace deprecated `middleware.ts` with `proxy.ts` using cookie-based session check to avoid importing `jazz-tools`/`kysely-libsql` in the Edge runtime (caused "invalid tag" crash)
- Fix `GET /api/auth/get-session` returning 500: use the correct `overrideUserInfoOnSignIn` option (was incorrectly `updateUserOnSignIn`) so the `user.update.before` hook fires on Google re-login and re-encrypts credentials with the current `BETTER_AUTH_SECRET`
- Add `user.update.before` database hook to backfill `encryptedCredentials` for existing users on Google sign-in
- Fix `app-sidebar` hardcoded empty avatar → `userData?.image`
- Add error logging wrapper to auth GET route

## Test plan

- [x] Sign out and sign back in with Google — user name/avatar should appear in sidebar
- [x] `GET /api/auth/get-session` should return 200 (not 500)
- [x] Unauthenticated routes redirect to `/login`
- [x] API routes return 401 when unauthenticated (not redirect)

🤖 Generated with [Claude Code](https://claude.com/claude-code)